### PR TITLE
Add system tray applet for GUI brightness control (Linux)

### DIFF
--- a/asdbctl-applet.desktop
+++ b/asdbctl-applet.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Apple Studio Display Brightness
+Comment=Control Apple Studio Display brightness from the system tray
+Exec=/usr/local/bin/asdbctl-applet
+Icon=display-brightness-symbolic
+Terminal=false
+Categories=Utility;Settings;HardwareSettings;
+StartupNotify=false
+X-GNOME-Autostart-enabled=true

--- a/asdbctl-applet.py
+++ b/asdbctl-applet.py
@@ -47,11 +47,11 @@ class BrightnessApplet:
         self.menu.append(Gtk.SeparatorMenuItem())
 
         # Increment/Decrement buttons
-        inc_item = Gtk.MenuItem(label="+ Increase")
+        inc_item = Gtk.MenuItem(label="+5%")
         inc_item.connect('activate', self.on_increment)
         self.menu.append(inc_item)
 
-        dec_item = Gtk.MenuItem(label="- Decrease")
+        dec_item = Gtk.MenuItem(label="-5%")
         dec_item.connect('activate', self.on_decrement)
         self.menu.append(dec_item)
 
@@ -129,11 +129,11 @@ class BrightnessApplet:
         self.brightness_label.set_label(f"Brightness: {self.current_brightness}%")
 
     def on_increment(self, item):
-        new_value = min(100, self.current_brightness + 10)
+        new_value = min(100, self.current_brightness + 5)
         self.set_brightness(new_value)
 
     def on_decrement(self, item):
-        new_value = max(0, self.current_brightness - 10)
+        new_value = max(0, self.current_brightness - 5)
         self.set_brightness(new_value)
 
     def on_preset_clicked(self, item, value):

--- a/asdbctl-applet.py
+++ b/asdbctl-applet.py
@@ -1,0 +1,156 @@
+#!/usr/bin/python3
+"""
+Apple Studio Display Brightness Applet
+System tray applet for controlling Apple Studio Display brightness via asdbctl.
+"""
+
+import subprocess
+import signal
+import sys
+
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('AppIndicator3', '0.1')
+from gi.repository import Gtk, AppIndicator3, GLib
+
+
+ASDBCTL_PATH = '/usr/bin/asdbctl'
+POLL_INTERVAL_MS = 5000
+APPINDICATOR_ID = 'asdbctl-brightness'
+
+
+class BrightnessApplet:
+    def __init__(self):
+        self.current_brightness = 0
+        self.display_connected = False
+
+        self.indicator = AppIndicator3.Indicator.new(
+            APPINDICATOR_ID,
+            'display-brightness-symbolic',
+            AppIndicator3.IndicatorCategory.HARDWARE
+        )
+        self.indicator.set_status(AppIndicator3.IndicatorStatus.PASSIVE)
+
+        self.build_menu()
+
+        self.check_display()
+        GLib.timeout_add(POLL_INTERVAL_MS, self.check_display)
+
+    def build_menu(self):
+        self.menu = Gtk.Menu()
+
+        # Brightness label
+        self.brightness_label = Gtk.MenuItem(label="Brightness: --%")
+        self.brightness_label.set_sensitive(False)
+        self.menu.append(self.brightness_label)
+
+        self.menu.append(Gtk.SeparatorMenuItem())
+
+        # Increment/Decrement buttons
+        inc_item = Gtk.MenuItem(label="+ Increase")
+        inc_item.connect('activate', self.on_increment)
+        self.menu.append(inc_item)
+
+        dec_item = Gtk.MenuItem(label="- Decrease")
+        dec_item.connect('activate', self.on_decrement)
+        self.menu.append(dec_item)
+
+        self.menu.append(Gtk.SeparatorMenuItem())
+
+        # Preset buttons
+        for preset in [25, 50, 75, 100]:
+            item = Gtk.MenuItem(label=f"{preset}%")
+            item.connect('activate', self.on_preset_clicked, preset)
+            self.menu.append(item)
+
+        self.menu.append(Gtk.SeparatorMenuItem())
+
+        # Quit
+        quit_item = Gtk.MenuItem(label="Quit")
+        quit_item.connect('activate', self.on_quit)
+        self.menu.append(quit_item)
+
+        self.menu.show_all()
+        self.indicator.set_menu(self.menu)
+
+    def run_asdbctl(self, *args):
+        try:
+            result = subprocess.run(
+                [ASDBCTL_PATH] + list(args),
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+            return result.returncode == 0, result.stdout.strip()
+        except subprocess.TimeoutExpired:
+            return False, ""
+        except Exception as e:
+            print(f"Error running asdbctl: {e}", file=sys.stderr)
+            return False, ""
+
+    def get_brightness(self):
+        success, output = self.run_asdbctl('get')
+        if success and output:
+            try:
+                parts = output.split()
+                if len(parts) >= 2:
+                    return int(parts[1])
+            except (ValueError, IndexError):
+                pass
+        return None
+
+    def set_brightness(self, value):
+        value = max(0, min(100, int(value)))
+        success, _ = self.run_asdbctl('set', str(value))
+        if success:
+            self.current_brightness = value
+            self.update_ui()
+        return success
+
+    def check_display(self):
+        brightness = self.get_brightness()
+        was_connected = self.display_connected
+        self.display_connected = brightness is not None
+
+        if self.display_connected:
+            self.current_brightness = brightness
+            self.indicator.set_status(AppIndicator3.IndicatorStatus.ACTIVE)
+            self.update_ui()
+        else:
+            self.indicator.set_status(AppIndicator3.IndicatorStatus.PASSIVE)
+
+        if was_connected != self.display_connected:
+            status = "connected" if self.display_connected else "disconnected"
+            print(f"Apple Studio Display {status}", file=sys.stderr)
+
+        return True
+
+    def update_ui(self):
+        self.brightness_label.set_label(f"Brightness: {self.current_brightness}%")
+
+    def on_increment(self, item):
+        new_value = min(100, self.current_brightness + 10)
+        self.set_brightness(new_value)
+
+    def on_decrement(self, item):
+        new_value = max(0, self.current_brightness - 10)
+        self.set_brightness(new_value)
+
+    def on_preset_clicked(self, item, value):
+        self.set_brightness(value)
+
+    def on_quit(self, item):
+        Gtk.main_quit()
+
+    def run(self):
+        Gtk.main()
+
+
+def main():
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    applet = BrightnessApplet()
+    applet.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/install-applet.sh
+++ b/install-applet.sh
@@ -23,7 +23,11 @@ done
 
 if [ -n "$DEPS_TO_INSTALL" ]; then
     echo "Installing:$DEPS_TO_INSTALL"
-    sudo apt-get install -y $DEPS_TO_INSTALL
+    sudo apt-get install -y $DEPS_TO_INSTALL || {
+        echo "ERROR: Failed to install dependencies. Please run manually:"
+        echo "  sudo apt-get install -y python3-gi gir1.2-appindicator3-0.1"
+        exit 1
+    }
 fi
 
 # Install udev rule for non-root access

--- a/install-applet.sh
+++ b/install-applet.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Installation script for Apple Studio Display Brightness Applet
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Installing Apple Studio Display Brightness Applet..."
+echo
+
+# Check for required dependencies
+echo "Checking dependencies..."
+DEPS_TO_INSTALL=""
+for pkg in python3-gi gir1.2-appindicator3-0.1; do
+    if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+        DEPS_TO_INSTALL="$DEPS_TO_INSTALL $pkg"
+    else
+        echo "  $pkg is already installed"
+    fi
+done
+
+if [ -n "$DEPS_TO_INSTALL" ]; then
+    echo "Installing:$DEPS_TO_INSTALL"
+    sudo apt-get install -y $DEPS_TO_INSTALL
+fi
+
+# Install udev rule for non-root access
+echo
+echo "Installing udev rule for non-root access..."
+if [ -f "/etc/udev/rules.d/20-asd-backlight.rules" ]; then
+    echo "  udev rule already exists, updating..."
+fi
+sudo cp "$SCRIPT_DIR/rules.d/20-asd-backlight.rules" /etc/udev/rules.d/
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+echo "  udev rule installed"
+
+# Install the applet script
+echo
+echo "Installing applet script..."
+sudo install -m 755 "$SCRIPT_DIR/asdbctl-applet.py" /usr/local/bin/asdbctl-applet
+echo "  Installed to /usr/local/bin/asdbctl-applet"
+
+# Install autostart entry
+echo
+echo "Installing autostart entry..."
+mkdir -p ~/.config/autostart
+cp "$SCRIPT_DIR/asdbctl-applet.desktop" ~/.config/autostart/
+echo "  Installed to ~/.config/autostart/"
+
+echo
+echo "============================================"
+echo "Installation complete!"
+echo "============================================"
+echo
+echo "IMPORTANT: For the udev rule to take effect, you need to either:"
+echo "  1. Unplug and replug the Apple Studio Display USB cable, OR"
+echo "  2. Reboot your system"
+echo
+echo "To start the applet now (for testing):"
+echo "  /usr/local/bin/asdbctl-applet &"
+echo
+echo "The applet will automatically start on next login."
+echo "It will only appear in your topbar when an Apple Studio Display is connected."


### PR DESCRIPTION
## Summary

  Adds a GNOME system tray applet for controlling Apple Studio Display brightness from the desktop, eliminating the need to use the command line.

  ## Features

  - System tray icon that appears only when an Apple Studio Display is connected
  - Displays current brightness percentage
  - Quick presets: 25%, 50%, 75%, 100%
  - Increment/decrement by 10%
  - Auto-detects display connection/disconnection (polls every 5 seconds)
  - Starts automatically on login

  ## New Files

  - `asdbctl-applet.py` - Python GTK3/AppIndicator3 applet
  - `asdbctl-applet.desktop` - Desktop entry for autostart
  - `install-applet.sh` - Installation script

  ## Installation

  ```bash
  ./install-applet.sh

  Then either:
  - Unplug and replug the display USB cable, OR
  - Reboot

  The applet will start automatically on login and appear in the top bar when the display is connected.

  Dependencies

  - python3-gi - Python GTK3 bindings
  - gir1.2-appindicator3-0.1 - AppIndicator3 bindings

  The install script handles these automatically.

  Note

  Uses /usr/bin/python3 (system Python) instead of /usr/bin/env python3 to ensure access to system GTK packages, which may not be available in pyenv/virtualenv environments.