### PR TITLE
Fix Studio Display XDR not being detected

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,6 @@ use std::{error::Error, vec::Vec};
 const REPORT_ID: u8 = 1;
 
 const MIN_BRIGHTNESS: u32 = 400;
-const MAX_BRIGHTNESS: u32 = 60000;
-const BRIGHTNESS_RANGE: u32 = MAX_BRIGHTNESS - MIN_BRIGHTNESS;
 
 const SD_VENDOR_ID: u16 = 0x05ac;
 const SD_INTERFACE_NR: i32 = 0x7;
@@ -16,6 +14,17 @@ const SD_PRODUCT_IDS: [u16; 3] = [
     0x1116, // Studio Display XDR (2026)
     0x1118, // Studio Display (2026)
 ];
+
+// The raw feature-report value that corresponds to 100% on macOS's own
+// brightness slider for each panel. This tracks the sustained full-screen
+// brightness spec (not the transient HDR peak), which is what macOS uses
+// for the slider ceiling.
+fn max_brightness_for(product_id: u16) -> u32 {
+    match product_id {
+        0x1116 => 100000, // Studio Display XDR (2026): 1000 nits sustained
+        _ => 60000,       // Studio Display (2022/2026): 600 nits
+    }
+}
 
 fn get_brightness(handle: &mut hidapi::HidDevice) -> Result<u32, Box<dyn Error>> {
     let mut buf = Vec::with_capacity(7); // report id, 4 bytes brightness, 2 bytes unknown
@@ -34,9 +43,13 @@ fn get_brightness(handle: &mut hidapi::HidDevice) -> Result<u32, Box<dyn Error>>
     Ok(brightness)
 }
 
-fn get_brightness_percent(handle: &mut hidapi::HidDevice) -> Result<u8, Box<dyn Error>> {
+fn get_brightness_percent(
+    handle: &mut hidapi::HidDevice,
+    max_brightness: u32,
+) -> Result<u8, Box<dyn Error>> {
+    let brightness_range = (max_brightness - MIN_BRIGHTNESS) as f32;
     let value = (get_brightness(handle)? - MIN_BRIGHTNESS) as f32;
-    let value_percent = (value / BRIGHTNESS_RANGE as f32 * 100.0) as u8;
+    let value_percent = (value / brightness_range * 100.0) as u8;
     Ok(value_percent)
 }
 
@@ -52,10 +65,11 @@ fn set_brightness(handle: &mut hidapi::HidDevice, brightness: u32) -> Result<(),
 fn set_brightness_percent(
     handle: &mut hidapi::HidDevice,
     brightness: u8,
+    max_brightness: u32,
 ) -> Result<(), Box<dyn Error>> {
-    let nits =
-        ((brightness as f32 * BRIGHTNESS_RANGE as f32) / 100.0 + MIN_BRIGHTNESS as f32) as u32;
-    let nits = std::cmp::min(nits, MAX_BRIGHTNESS);
+    let brightness_range = (max_brightness - MIN_BRIGHTNESS) as f32;
+    let nits = ((brightness as f32 * brightness_range) / 100.0 + MIN_BRIGHTNESS as f32) as u32;
+    let nits = std::cmp::min(nits, max_brightness);
     let nits = std::cmp::max(nits, MIN_BRIGHTNESS);
     set_brightness(handle, nits)?;
     Ok(())
@@ -134,6 +148,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     for display in displays {
         let mut handle = hapi.open_path(display.path())?;
+        let max_brightness = max_brightness_for(display.product_id());
         if let Some(s) = display.serial_number() {
             info!("display serial number {}", s);
         }
@@ -146,24 +161,24 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
         match matches.subcommand() {
             Some(("get", _)) => {
-                let brightness = get_brightness_percent(&mut handle)?;
+                let brightness = get_brightness_percent(&mut handle, max_brightness)?;
                 println!("brightness {}", brightness);
             }
             Some(("set", sub_matches)) => {
                 let brightness = *sub_matches.get_one::<u8>("BRIGHTNESS").expect("required");
-                set_brightness_percent(&mut handle, brightness)?;
+                set_brightness_percent(&mut handle, brightness, max_brightness)?;
             }
             Some(("up", sub_matches)) => {
                 let step = *sub_matches.get_one::<u8>("step").expect("required");
-                let brightness = get_brightness_percent(&mut handle)?;
+                let brightness = get_brightness_percent(&mut handle, max_brightness)?;
                 let new_brightness = std::cmp::min(100, brightness + step);
-                set_brightness_percent(&mut handle, new_brightness)?;
+                set_brightness_percent(&mut handle, new_brightness, max_brightness)?;
             }
             Some(("down", sub_matches)) => {
                 let step = *sub_matches.get_one::<u8>("step").expect("required");
-                let brightness = get_brightness_percent(&mut handle)?;
+                let brightness = get_brightness_percent(&mut handle, max_brightness)?;
                 let new_brightness = std::cmp::max(0, brightness as i32 - step as i32) as u8;
-                set_brightness_percent(&mut handle, new_brightness)?;
+                set_brightness_percent(&mut handle, new_brightness, max_brightness)?;
             }
             _ => unreachable!(),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,12 @@ fn cli() -> Command {
         .arg(
             arg!(-v --verbose ... "Turn debugging information on")
         )
-        .subcommand(Command::new("get").about("Get the current brightness in %"))
+        .subcommand(
+            Command::new("get").about("Get the current brightness in %").arg(
+                arg!(-r --raw "Print the raw HID feature-report value instead of a percentage")
+                    .required(false),
+            ),
+        )
         .subcommand(
             Command::new("set")
                 .about("Set the current brightness in %")
@@ -160,9 +165,14 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
         }
         match matches.subcommand() {
-            Some(("get", _)) => {
-                let brightness = get_brightness_percent(&mut handle, max_brightness)?;
-                println!("brightness {}", brightness);
+            Some(("get", sub_matches)) => {
+                if sub_matches.get_flag("raw") {
+                    let raw = get_brightness(&mut handle)?;
+                    println!("raw {}", raw);
+                } else {
+                    let brightness = get_brightness_percent(&mut handle, max_brightness)?;
+                    println!("brightness {}", brightness);
+                }
             }
             Some(("set", sub_matches)) => {
                 let brightness = *sub_matches.get_one::<u8>("BRIGHTNESS").expect("required");

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ use std::{error::Error, vec::Vec};
 const REPORT_ID: u8 = 1;
 
 const MIN_BRIGHTNESS: u32 = 400;
+const MAX_BRIGHTNESS: u32 = 60000;
+const BRIGHTNESS_RANGE: u32 = MAX_BRIGHTNESS - MIN_BRIGHTNESS;
 
 const SD_VENDOR_ID: u16 = 0x05ac;
 // The brightness feature report lives on the standard USB HID "Monitor"
@@ -22,17 +24,6 @@ const SD_PRODUCT_IDS: [u16; 3] = [
     0x1116, // Studio Display XDR (2026)
     0x1118, // Studio Display (2026)
 ];
-
-// The raw feature-report value that corresponds to 100% on macOS's own
-// brightness slider for each panel. This tracks the sustained full-screen
-// brightness spec (not the transient HDR peak), which is what macOS uses
-// for the slider ceiling.
-fn max_brightness_for(product_id: u16) -> u32 {
-    match product_id {
-        0x1116 => 100000, // Studio Display XDR (2026): 1000 nits sustained
-        _ => 60000,       // Studio Display (2022/2026): 600 nits
-    }
-}
 
 fn get_brightness(handle: &mut hidapi::HidDevice) -> Result<u32, Box<dyn Error>> {
     let mut buf = Vec::with_capacity(7); // report id, 4 bytes brightness, 2 bytes unknown
@@ -51,13 +42,9 @@ fn get_brightness(handle: &mut hidapi::HidDevice) -> Result<u32, Box<dyn Error>>
     Ok(brightness)
 }
 
-fn get_brightness_percent(
-    handle: &mut hidapi::HidDevice,
-    max_brightness: u32,
-) -> Result<u8, Box<dyn Error>> {
-    let brightness_range = (max_brightness - MIN_BRIGHTNESS) as f32;
+fn get_brightness_percent(handle: &mut hidapi::HidDevice) -> Result<u8, Box<dyn Error>> {
     let value = (get_brightness(handle)? - MIN_BRIGHTNESS) as f32;
-    let value_percent = (value / brightness_range * 100.0) as u8;
+    let value_percent = (value / BRIGHTNESS_RANGE as f32 * 100.0) as u8;
     Ok(value_percent)
 }
 
@@ -73,11 +60,10 @@ fn set_brightness(handle: &mut hidapi::HidDevice, brightness: u32) -> Result<(),
 fn set_brightness_percent(
     handle: &mut hidapi::HidDevice,
     brightness: u8,
-    max_brightness: u32,
 ) -> Result<(), Box<dyn Error>> {
-    let brightness_range = (max_brightness - MIN_BRIGHTNESS) as f32;
-    let nits = ((brightness as f32 * brightness_range) / 100.0 + MIN_BRIGHTNESS as f32) as u32;
-    let nits = std::cmp::min(nits, max_brightness);
+    let nits =
+        ((brightness as f32 * BRIGHTNESS_RANGE as f32) / 100.0 + MIN_BRIGHTNESS as f32) as u32;
+    let nits = std::cmp::min(nits, MAX_BRIGHTNESS);
     let nits = std::cmp::max(nits, MIN_BRIGHTNESS);
     set_brightness(handle, nits)?;
     Ok(())
@@ -180,7 +166,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     for display in displays {
         let mut handle = hapi.open_path(display.path())?;
-        let max_brightness = max_brightness_for(display.product_id());
         if let Some(s) = display.serial_number() {
             info!("display serial number {}", s);
         }
@@ -197,25 +182,25 @@ fn main() -> Result<(), Box<dyn Error>> {
                     let raw = get_brightness(&mut handle)?;
                     println!("raw {}", raw);
                 } else {
-                    let brightness = get_brightness_percent(&mut handle, max_brightness)?;
+                    let brightness = get_brightness_percent(&mut handle)?;
                     println!("brightness {}", brightness);
                 }
             }
             Some(("set", sub_matches)) => {
                 let brightness = *sub_matches.get_one::<u8>("BRIGHTNESS").expect("required");
-                set_brightness_percent(&mut handle, brightness, max_brightness)?;
+                set_brightness_percent(&mut handle, brightness)?;
             }
             Some(("up", sub_matches)) => {
                 let step = *sub_matches.get_one::<u8>("step").expect("required");
-                let brightness = get_brightness_percent(&mut handle, max_brightness)?;
+                let brightness = get_brightness_percent(&mut handle)?;
                 let new_brightness = std::cmp::min(100, brightness + step);
-                set_brightness_percent(&mut handle, new_brightness, max_brightness)?;
+                set_brightness_percent(&mut handle, new_brightness)?;
             }
             Some(("down", sub_matches)) => {
                 let step = *sub_matches.get_one::<u8>("step").expect("required");
-                let brightness = get_brightness_percent(&mut handle, max_brightness)?;
+                let brightness = get_brightness_percent(&mut handle)?;
                 let new_brightness = std::cmp::max(0, brightness as i32 - step as i32) as u8;
-                set_brightness_percent(&mut handle, new_brightness, max_brightness)?;
+                set_brightness_percent(&mut handle, new_brightness)?;
             }
             _ => unreachable!(),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,15 @@ const REPORT_ID: u8 = 1;
 const MIN_BRIGHTNESS: u32 = 400;
 
 const SD_VENDOR_ID: u16 = 0x05ac;
-const SD_INTERFACE_NR: i32 = 0x7;
+// The brightness feature report lives on the standard USB HID "Monitor"
+// top-level collection (usage page 0x80, usage 0x01). The interface number
+// that collection shows up on isn't stable -- it was hardcoded to 7 (which
+// worked for the original Studio Display) but the Studio Display XDR
+// exposes it as interface 14 instead -- so match on usage page/usage,
+// which is a property of the HID report descriptor itself, not something
+// hidapi derives per-platform/per-device.
+const SD_USAGE_PAGE: u16 = 0x0080;
+const SD_USAGE: u16 = 0x0001;
 const SD_PRODUCT_IDS: [u16; 3] = [
     0x1114, // Studio Display (2022)
     0x1116, // Studio Display XDR (2026)
@@ -81,7 +89,8 @@ fn studio_displays(hapi: &HidApi) -> Result<Vec<&hidapi::DeviceInfo>, Box<dyn Er
         .filter(|x| {
             SD_PRODUCT_IDS.contains(&x.product_id())
                 && x.vendor_id() == SD_VENDOR_ID
-                && x.interface_number() == SD_INTERFACE_NR
+                && x.usage_page() == SD_USAGE_PAGE
+                && x.usage() == SD_USAGE
         })
         .collect())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,10 @@ fn cli() -> Command {
                 .arg_required_else_help(true),
         )
         .subcommand(
+            Command::new("list-interfaces")
+                .about("Debug: list every HID interface exposed by connected Apple devices matching the Studio Display vendor ID"),
+        )
+        .subcommand(
             Command::new("up")
                 .arg(
                     arg!(-s --step <STEP> "Step size in percent")
@@ -145,6 +149,20 @@ fn main() -> Result<(), Box<dyn Error>> {
         .unwrap();
 
     let hapi = HidApi::new()?;
+
+    if matches.subcommand_matches("list-interfaces").is_some() {
+        for x in hapi.device_list().filter(|x| x.vendor_id() == SD_VENDOR_ID) {
+            println!(
+                "product_id=0x{:04x} interface_number={} usage_page=0x{:04x} usage=0x{:04x} path={:?}",
+                x.product_id(),
+                x.interface_number(),
+                x.usage_page(),
+                x.usage(),
+                x.path()
+            );
+        }
+        return Ok(());
+    }
 
     let displays = studio_displays(&hapi)?;
     if displays.is_empty() {


### PR DESCRIPTION
## Summary

The brightness ceiling in the issue turned out not to be the bug — I tested against real Studio Display XDR hardware and macOS's own brightness slider sends raw `60000` at 100% and raw `400` at 0%, identical to the existing `MIN_BRIGHTNESS`/`MAX_BRIGHTNESS` constants. The extra headroom up to raw `160000` from the issue is real panel capability, but it sits above what macOS itself exposes via its slider, so per @juliuszint's ask to match macOS's 100% behavior, no ceiling change is needed.

The actual bug, found while testing: **the XDR isn't detected by `asdbctl` at all** ("No Apple Studio Display found"), because its brightness-control HID collection sits on a different USB interface number (`14`) than the original Studio Display (`7`), which `SD_INTERFACE_NR` hardcoded. Interface numbers aren't a stable property to match on across devices/platforms anyway — the brightness feature report actually lives on the standard USB HID "Monitor" top-level collection (usage page `0x80`, usage `0x01`), so `studio_displays()` now matches on that instead.

Also adds two small debug aids that were useful for tracking this down and should help with any future device-detection reports:
- `get --raw` prints the raw HID feature-report value instead of a percentage
- `list-interfaces` lists every HID interface under the Studio Display vendor ID, regardless of product ID/interface number, for diagnosing detection issues

Fixes #16

## Test plan
- [x] `cargo build` / `cargo clippy` / `cargo fmt -- --check` all clean
- [x] Verified on real Studio Display XDR hardware: previously failed with "No Apple Studio Display found", now correctly detected
- [x] Verified `get`/`get --raw` read correct values at 0% and 100% via the native macOS slider
- [x] Confirmed `MIN_BRIGHTNESS`/`MAX_BRIGHTNESS` (400/60000) match macOS's own slider range on XDR, so `set <percent>` needs no XDR-specific ceiling